### PR TITLE
Support editing messages

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -48,6 +48,39 @@ messageForm.addEventListener('submit', (e) => {
     entry.remove();
   });
   newMessage.appendChild(removeButton);
+
+  // add `edit` button after new message 
+
+  const editSaveButton = document.createElement('button');
+  editSaveButton.innerHTML = 'edit'
+  editSaveButton.addEventListener('click', (e) => {
+    const li = e.target.parentNode;
+    if (editSaveButton.innerHTML === 'edit') {
+      makeMessageEditable(li);
+      editSaveButton.innerHTML = 'save';
+    } else {
+      saveEditedMessage(li);
+      editSaveButton.innerHTML = 'edit';
+    }
+  });
+  newMessage.appendChild(editSaveButton);
+
   messagesList.appendChild(newMessage);
   messageForm.reset();
-})
+});
+
+function makeMessageEditable(li) {
+  const message = li.querySelector('span');
+
+  const input = document.createElement('input');
+  input.value = message.innerHTML;
+  li.replaceChild(input, message);
+}
+
+function saveEditedMessage(li) {
+  const input = li.querySelector('input');
+
+  const message = document.createElement('span');
+  message.innerHTML = input.value;
+  li.replaceChild(message, input);
+}


### PR DESCRIPTION
In order to edit an existing message in our HTML page, we need to swap out the `<span>` element for an `<input>` element (keeping the message's content). Once we're done editing, we need to swap the `<input>` element back to a `<span>` element. 

We use the same button for both the `edit` and `save` function, but change the `innerHTML` between edit and save so that the button's behavior is always clear.

![Screen Recording 2021-07-29 at 8 56 23 AM mov](https://user-images.githubusercontent.com/15333061/127496735-bb26c081-7c11-4ef9-bbad-ff39a008967b.gif)
